### PR TITLE
Delay searching by 500 ms on each keypress

### DIFF
--- a/src/search-box.js
+++ b/src/search-box.js
@@ -64,11 +64,14 @@ var SearchBox = function(options) {
   }
 };
 
+var searchTrigger = null;
+
 SearchBox.prototype = {
   _input: function() {
     if (this._state.query != this._in.value) {
       this._state.query = this._in.value;
-      this._search();
+      window.clearTimeout(searchTrigger);
+      searchTrigger = window.setTimeout(this._search.bind(this), 500);
     }
   },
 


### PR DESCRIPTION
Currently it searches on every single key press (including starting a search so single letter domains so on until you reach your desired domain). So if you want to search trial.com you would consume 9 API calls (one for t, one for tr, one for tri, etc etc). That is a bit ridiculous and should be delayed for a bit so two simultaneous key presses (or very very close) don't trigger multiple API calls.

This delays the searching by 500ms on each keypress, that may be a bit high so I'm open for suggestions.
