### PR TITLE
Fixed issue with searching for empty query

### DIFF
--- a/src/search-box.js
+++ b/src/search-box.js
@@ -67,6 +67,11 @@ var SearchBox = function(options) {
 SearchBox.prototype = {
   _input: function() {
     if (this._state.query != this._in.value) {
+      if (this._in.value === '') {
+        this._state.results = [];
+        this._update();
+        return;
+      }
       this._state.query = this._in.value;
       this._search();
     }


### PR DESCRIPTION
If the field is empty it would still run a search (api call), now if the field is empty is clears the search results and does not run a search.
